### PR TITLE
Fix vite not found in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,20 @@ FROM node:22-alpine AS base
 WORKDIR /app
 ENV NODE_ENV=production
 
-# Install deps
+# Copy package files for all workspaces first
 COPY package.json package-lock.json* pnpm-lock.yaml* yarn.lock* ./
+COPY client/package.json ./client/
+COPY server/package.json ./server/
+COPY shared/package.json ./shared/
+
+# Install dependencies for all workspaces
 RUN npm ci --ignore-scripts
 
-# Build client
+# Build stage
 FROM base AS build
 WORKDIR /app
 COPY . .
+# Build both client and server
 RUN npm run -w client build && npm run -w server build
 
 # Runtime image


### PR DESCRIPTION
Update Dockerfile to correctly install monorepo workspace dependencies, resolving build failures.

The previous Dockerfile failed to build because `npm ci` was run before all workspace `package.json` files were copied, leading to `vite` and other dev dependencies not being available in the build stage. This change ensures all workspace package files are copied first, allowing `npm ci` to properly resolve and install all necessary dependencies for both client and server builds.

---
<a href="https://cursor.com/background-agent?bcId=bc-ecc3d4e2-dfe0-4bca-9064-47452c3b2268">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ecc3d4e2-dfe0-4bca-9064-47452c3b2268">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

