### PR TITLE
Fix vite not found error during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,14 +10,17 @@ COPY client/package.json ./client/
 COPY server/package.json ./server/
 COPY shared/package.json ./shared/
 
-# Install dependencies for all workspaces
-RUN npm ci --ignore-scripts
+# Install dependencies for all workspaces (remove --ignore-scripts to ensure proper workspace setup)
+RUN npm ci
 
 # Build stage
 FROM base AS build
 WORKDIR /app
 # Copy node_modules from base stage first
 COPY --from=base /app/node_modules ./node_modules
+COPY --from=base /app/client/node_modules ./client/node_modules
+COPY --from=base /app/server/node_modules ./server/node_modules
+COPY --from=base /app/shared/node_modules ./shared/node_modules
 # Copy source code (excluding node_modules)
 COPY . .
 # Build both client and server
@@ -30,6 +33,9 @@ ENV NODE_ENV=production
 
 # Copy node_modules and built artifacts
 COPY --from=base /app/node_modules ./node_modules
+COPY --from=base /app/client/node_modules ./client/node_modules
+COPY --from=base /app/server/node_modules ./server/node_modules
+COPY --from=base /app/shared/node_modules ./shared/node_modules
 COPY --from=build /app/client/dist ./client/dist
 COPY --from=build /app/server/dist ./server/dist
 COPY --from=build /app/shared/dist ./shared/dist


### PR DESCRIPTION
Ensure all workspace dependencies are available during Docker build to resolve 'vite: not found' error.

The previous Dockerfile used `npm ci --ignore-scripts`, which prevented proper setup of workspace dependencies. This resulted in `vite` not being available in the client directory during the build step. This PR removes the `--ignore-scripts` flag and explicitly copies `node_modules` from each workspace to ensure all necessary tools are present.

---
<a href="https://cursor.com/background-agent?bcId=bc-f7b492cf-5a86-478f-8367-304156999d23">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f7b492cf-5a86-478f-8367-304156999d23">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

